### PR TITLE
Fix "order_number" param handling.

### DIFF
--- a/authorize/response_parser.py
+++ b/authorize/response_parser.py
@@ -13,6 +13,7 @@ RENAME_FIELDS = {
     'ids': 'profile_ids',
     'shipping': 'shipping_and_handling',
     'directResponse': 'transaction_response',
+    'purchaseOrderNumber': 'order_number',
 }
 
 DIRECT_RESPONSE_FIELDS = {

--- a/authorize/schemas.py
+++ b/authorize/schemas.py
@@ -256,9 +256,6 @@ class CIMBaseSchema(colander.MappingSchema):
 
 
 class CIMTransactionSchema(CIMBaseSchema, TransactionBaseSchema):
-    purchase_order_number = colander.SchemaNode(colander.String(),
-                                                validator=colander.Length(max=25),
-                                                missing=colander.drop)
     recurring = colander.SchemaNode(colander.Boolean(),
                                     missing=colander.drop)
     card_code = colander.SchemaNode(colander.String(),

--- a/authorize/xml_data.py
+++ b/authorize/xml_data.py
@@ -104,6 +104,8 @@ def create_order(params={}):
         E.SubElement(order, 'invoiceNumber').text = params['invoice_number']
     if 'description' in params:
         E.SubElement(order, 'description').text = params['description']
+    if 'order_number' in params:
+        E.SubElement(order, 'purchaseOrderNumber').text = params['order_number']
     return order
 
 

--- a/docs/transaction.rst
+++ b/docs/transaction.rst
@@ -108,7 +108,6 @@ Full Example
         'order': {
             'invoice_number': 'INV0001',
             'description': 'Just another invoice...',
-            'order_number': 'PONUM00001',
         },
         'shipping_and_handling': {
             'amount': 10.00,
@@ -223,7 +222,6 @@ Full Transactions with Bank Accounts
         'order': {
             'invoice_number': 'INV0001',
             'description': 'Just another invoice...',
-            'order_number': 'PONUM00001',
         },
         'shipping_and_handling': {
             'amount': 10.00,

--- a/tests/test_live_transaction.py
+++ b/tests/test_live_transaction.py
@@ -75,7 +75,6 @@ FULL_CARD_TRANSACTION = {
     'order': {
         'invoice_number': 'INV0001',
         'description': 'Just another invoice...',
-        'order_number': 'PONUM00001',
     },
     'shipping_and_handling': {
         'amount': 10.00,
@@ -209,7 +208,6 @@ FULL_ACCOUNT_TRANSACTION = {
     'order': {
         'invoice_number': 'INV0001',
         'description': 'Just another invoice...',
-        'order_number': 'PONUM00001',
     },
     'shipping_and_handling': {
         'amount': 10.00,
@@ -274,7 +272,8 @@ class TransactionTests(TestCase):
         transaction['amount'] = random.randrange(100, 100000) / 100.0
         result = Transaction.auth(transaction)
         # Read transaction details
-        Transaction.details(result.transaction_response.trans_id)
+        result = Transaction.details(result.transaction_response.trans_id)
+        self.assertEqual(result.transaction.order.order_number, 'PONUM00001')
 
     def test_auth_and_settle_transaction(self):
         transaction = FULL_CARD_TRANSACTION.copy()

--- a/tests/test_transaction_api.py
+++ b/tests/test_transaction_api.py
@@ -129,7 +129,6 @@ FULL_AIM_TRANSACTION = {
     'order': {
         'invoice_number': 'INV0001',
         'description': 'Just another invoice...',
-        'order_number': 'PONUM00001',
     },
     'shipping_and_handling': {
         'amount': 10.00,
@@ -201,6 +200,7 @@ CIM_SALE_REQUEST = u'''
       <order>
         <invoiceNumber>INV0001</invoiceNumber>
         <description>Just another invoice...</description>
+        <purchaseOrderNumber>PONUM00001</purchaseOrderNumber>
       </order>
       <taxExempt>false</taxExempt>
       <recurringBilling>true</recurringBilling>


### PR DESCRIPTION
Hi, during testing we grabbed yet another irregularity about "order_number" param.

According to docs:
1) AIM: www.authorize.net/support/AIM_guide_XML.pdf‎
2) ARB: www.authorize.net/support/ARB_SOAP_guide.pdf‎
3) CIM: www.authorize.net/support/CIM_SOAP_guide.pdf‎

Sounds strange, but "purchaseOrderNumber" in  node "Order" is allowed ONLY on CIM transactions.

Initially we sent this parameter, but we not received it in response (eg. for Transaction.details request). When debugging, it turned out that it is not handle to XML request, so we implemented this. We have seen in the CIM transaction scheme purchase_order_number, but it seems to us that it was in the wrong place, so redundant. We had to change the tests and docs, so please carefully review this pull request and check if we're not wrong.
