### PR TITLE
Added functionality to send amount when settling transactions

### DIFF
--- a/authorize/apis/transaction_api.py
+++ b/authorize/apis/transaction_api.py
@@ -31,8 +31,8 @@ class TransactionAPI(BaseAPI):
             xact = self._deserialize(AIMTransactionSchema(), params)
             return self.api._make_call(self._aim_base_request('authOnlyTransaction', xact))
 
-    def settle(self, transaction_id):
-        return self.api._make_call(self._settle_request(transaction_id))
+    def settle(self, params={}):
+        return self.api._make_call(self._settle_request(params))
 
     def credit(self, params={}):
         xact = self._deserialize(CreditTransactionSchema(), params)
@@ -154,11 +154,15 @@ class TransactionAPI(BaseAPI):
 
         return request
 
-    def _settle_request(self, transaction_id):
+    def _settle_request(self, xact):
         request = self.api._base_request('createTransactionRequest')
         xact_elem = E.SubElement(request, 'transactionRequest')
         E.SubElement(xact_elem, 'transactionType').text = 'priorAuthCaptureTransaction'
-        E.SubElement(xact_elem, 'refTransId').text = transaction_id
+
+        if 'amount' in xact:
+            E.SubElement(xact_elem, 'amount').text = quantize(xact['amount'])
+
+        E.SubElement(xact_elem, 'refTransId').text = xact['transaction_id']
         return request
 
     def _refund_request(self, xact):

--- a/docs/transaction.rst
+++ b/docs/transaction.rst
@@ -404,8 +404,12 @@ Example
 
 .. code-block:: python
 
-    result = authorize.Transaction.settle('89798235')
+    result = authorize.Transaction.settle({
+        'amount': 40.00,
+        'transaction_id': '89798235'
+    })
 
+The amount is not required if you want to settle the authorized amount.
 
 Refund
 ------

--- a/tests/test_live_transaction.py
+++ b/tests/test_live_transaction.py
@@ -374,13 +374,37 @@ class TransactionTests(TestCase):
         transaction = FULL_CARD_NOT_PRESENT_TRANSACTION.copy()
         transaction['amount'] = random.randrange(100, 100000) / 100.0
         result = Transaction.auth(transaction)
-        Transaction.settle(result.transaction_response.trans_id)
+        settle_transaction = {
+            'amount': transaction['amount'] - 0.9,
+            'transaction_id': result.transaction_response.trans_id,
+        }
+        Transaction.settle(settle_transaction)
+
+        transaction_details = Transaction.details(result.transaction_response.trans_id)
+        self.assertEqual(
+            transaction_details.transaction.auth_amount, "%.2f" % transaction['amount']
+        )
+        self.assertEqual(
+            transaction_details.transaction.settle_amount, "%.2f" % settle_transaction['amount']
+        )
 
     def test_auth_and_settle_card_present_transaction(self):
         transaction = FULL_CARD_PRESENT_TRANSACTION.copy()
         transaction['amount'] = random.randrange(100, 100000) / 100.0
         result = Transaction.auth(transaction)
-        Transaction.settle(result.transaction_response.trans_id)
+        settle_transaction = {
+            'amount': transaction['amount'] - 0.9,
+            'transaction_id': result.transaction_response.trans_id,
+        }
+        Transaction.settle(settle_transaction)
+
+        transaction_details = Transaction.details(result.transaction_response.trans_id)
+        self.assertEqual(
+            transaction_details.transaction.auth_amount, "%.2f" % transaction['amount']
+        )
+        self.assertEqual(
+            transaction_details.transaction.settle_amount, "%.2f" % settle_transaction['amount']
+        )
 
     def test_credit(self):
         result = Customer.create(CUSTOMER)

--- a/tests/test_transaction_api.py
+++ b/tests/test_transaction_api.py
@@ -501,6 +501,7 @@ SETTLE_REQUEST = '''
   </merchantAuthentication>
   <transactionRequest>
     <transactionType>priorAuthCaptureTransaction</transactionType>
+    <amount>20.00</amount>
     <refTransId>87912412523</refTransId>
   </transactionRequest>
 </createTransactionRequest>
@@ -604,8 +605,10 @@ class TransactionAPITests(TestCase):
             .replace('AuthCapture', 'AuthOnly'))
 
     def test_settle_request(self):
-        request_xml = Configuration.api.transaction._settle_request(
-            '87912412523')
+        request_xml = Configuration.api.transaction._settle_request({
+            'amount': 20.00,
+            'transaction_id': '87912412523'
+        })
         request_string = prettify(request_xml)
         self.assertEqual(request_string, SETTLE_REQUEST.strip())
 


### PR DESCRIPTION
@vcatalano  Hi man. Thanks for this awesome API. In my pull request I have added the functionality to send amount when we settle transactions. Please respond if you want me to make any changes.
 I wonder why you didn't add this functionality, on the other hand I am happy to have contributed to your API.

PS: No idea why the Travis build is failing. Maybe, because of connection problem with "authorize.net". It fails with error "socket.error: [Errno 104] Connection reset by peer"
