### PR TITLE
handle masked credit cards on update

### DIFF
--- a/authorize/schemas.py
+++ b/authorize/schemas.py
@@ -1,18 +1,23 @@
 import colander
-import re
 
 from datetime import date
 from uuid import uuid4
 
 
 @colander.deferred
-def mechant_id(node, kw):
+def merchant_id(node, kw):
     return uuid4().hex[:20]
 
 
 @colander.deferred
 def today(node, kw):
     return date.today().isoformat()
+
+
+def card_number(node, value):
+    if value.startswith('XXXX'):
+        return
+    colander.luhnok(node, value)
 
 
 class AddressSchema(colander.MappingSchema):
@@ -50,8 +55,8 @@ class AddressSchema(colander.MappingSchema):
 
 class CreditCardSchema(colander.MappingSchema):
     card_number = colander.SchemaNode(colander.String(),
-                                      validator=colander.luhnok,
-                                      requird=True)
+                                      validator=card_number,
+                                      required=True)
     expiration_month = colander.SchemaNode(colander.Integer(),
                                            validator=colander.Range(1, 12),
                                            missing=None)
@@ -99,12 +104,12 @@ class TrackDataSchema(colander.MappingSchema):
                                   validator=colander.Regex(
                                   r'^%?B\d{1,19}\^[A-Z /]{2,26}\^(\d|\^){4}(\d|\^){3}.*\??$', 'Track 1 does not match IATA format'),
                                   missing=colander.drop,
-                                  requird=None)
+                                  required=None)
     track_2 = colander.SchemaNode(colander.String(),
                                   validator=colander.Regex(
                                   r'^;?\d{1,19}=(\d|=){4}(\d|=){3}.*\??$', 'Track 2 does not match ABA format'),
                                   missing=colander.drop,
-                                  requird=None)
+                                  required=None)
 
     @staticmethod
     def validator(node, kw):
@@ -186,7 +191,7 @@ class CreateBankAccountSchema(BankAccountSchema, CustomerTypeSchema):
 class CustomerBaseSchema(colander.MappingSchema):
     merchant_id = colander.SchemaNode(colander.String(),
                                       validator=colander.Length(max=20),
-                                      missing=mechant_id)
+                                      missing=merchant_id)
     description = colander.SchemaNode(colander.String(),
                                       validator=colander.Length(max=255),
                                       missing=colander.drop)

--- a/tests/test_credit_card_api.py
+++ b/tests/test_credit_card_api.py
@@ -23,6 +23,26 @@ CREDIT_CARD = {
     },
 }
 
+MASKED_CREDIT_CARD = {
+    'customer_type': 'individual',
+    'card_number': 'XXXX1111',
+    'card_code': '456',
+    'expiration_month': '04',
+    'expiration_year': '2014',
+    'billing': {
+        'first_name': 'Rob',
+        'last_name': 'Oteron',
+        'company': 'Robotron Studios',
+        'address': '101 Computer Street',
+        'city': 'Tucson',
+        'state': 'AZ',
+        'zip': '85704',
+        'country': 'US',
+        'phone_number': '520-123-4567',
+        'fax_number': '520-456-7890',
+    },
+}
+
 VALIDATE_CREDIT_CARD = {
     'address_id': '7982053235',
     'card_code': '456',
@@ -108,6 +128,40 @@ UPDATE_CREDIT_CARD_REQUEST = '''
 </updateCustomerPaymentProfileRequest>
 '''
 
+UPDATE_CREDIT_CARD_REQUEST_MASKED_NUMBER = '''
+<?xml version="1.0" ?>
+<updateCustomerPaymentProfileRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
+  <merchantAuthentication>
+    <name>8s8tVnG5t</name>
+    <transactionKey>5GK7mncw8mG2946z</transactionKey>
+  </merchantAuthentication>
+  <customerProfileId>1234567890</customerProfileId>
+  <paymentProfile>
+    <customerType>individual</customerType>
+    <billTo>
+      <firstName>Rob</firstName>
+      <lastName>Oteron</lastName>
+      <company>Robotron Studios</company>
+      <address>101 Computer Street</address>
+      <city>Tucson</city>
+      <state>AZ</state>
+      <zip>85704</zip>
+      <country>US</country>
+      <phoneNumber>520-123-4567</phoneNumber>
+      <faxNumber>520-456-7890</faxNumber>
+    </billTo>
+    <payment>
+      <creditCard>
+        <cardNumber>XXXX1111</cardNumber>
+        <expirationDate>2014-04</expirationDate>
+        <cardCode>456</cardCode>
+      </creditCard>
+    </payment>
+    <customerPaymentProfileId>0987654321</customerPaymentProfileId>
+  </paymentProfile>
+</updateCustomerPaymentProfileRequest>
+'''
+
 DELETE_CREDIT_CARD_REQUEST = '''
 <?xml version="1.0" ?>
 <deleteCustomerPaymentProfileRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
@@ -154,6 +208,11 @@ class CreditCardAPITests(TestCase):
         request_xml = Configuration.api.credit_card._update_request('1234567890', '0987654321', CREDIT_CARD)
         request_string = prettify(request_xml)
         self.assertEqual(request_string, UPDATE_CREDIT_CARD_REQUEST.strip())
+
+    def test_update_credit_card_request_masked(self):
+        request_xml = Configuration.api.credit_card._update_request('1234567890', '0987654321', MASKED_CREDIT_CARD)
+        request_string = prettify(request_xml)
+        self.assertEqual(request_string, UPDATE_CREDIT_CARD_REQUEST_MASKED_NUMBER.strip())
 
     def test_delete_credit_card_request(self):
         request_xml = Configuration.api.credit_card._delete_request('1234567890', '0987654321')

--- a/tests/test_live_credit_card.py
+++ b/tests/test_live_credit_card.py
@@ -14,6 +14,12 @@ CREDIT_CARD = {
     'card_code': '456',
 }
 
+MASKED_CREDIT_CARD = {
+    'card_number': 'XXXX1111',
+    'expiration_date': '05/{0}'.format(date.today().year+2),
+    'card_code': '789'
+}
+
 FULL_CREDIT_CARD = {
     'card_number': '4111111111111111',
     'expiration_date': '04/{0}'.format(date.today().year + 1),
@@ -62,6 +68,9 @@ class CreditCardTests(TestCase):
 
         # Update credit card
         CreditCard.update(customer_id, payment_id, CREDIT_CARD)
+
+        # Update with masked number
+        CreditCard.update(customer_id, payment_id, MASKED_CREDIT_CARD)
 
         # Delete tests
         CreditCard.delete(customer_id, payment_id)


### PR DESCRIPTION
This fixes #30 (cannot use masked card numbers) and #31 ('requird' :point_right: 'required').

In addition to fixing the above issues:

- I removed the unused `re` import here
- I corrected another typo `mechant_id` :point_right: `merchant_id`