### PR TITLE
Adding card code to CIM request

### DIFF
--- a/authorize/apis/transaction_api.py
+++ b/authorize/apis/transaction_api.py
@@ -80,6 +80,9 @@ class TransactionAPI(BaseAPI):
         # CIM information
         E.SubElement(xact_type, 'customerProfileId').text = xact['customer_id']
         E.SubElement(xact_type, 'customerPaymentProfileId').text = xact['payment_id']
+        
+        if 'card_code' in xact:
+            E.SubElement(xact_type, 'cardCode').text = xact['card_code']
 
         if 'address_id' in xact:
             E.SubElement(xact_type, 'customerShippingAddressId').text = xact['address_id']
@@ -99,7 +102,6 @@ class TransactionAPI(BaseAPI):
                 extra_options['x_customer_ip'] = xact['extra_options']['customer_ip']
             options = E.SubElement(request, 'extraOptions')
             E.SubElement(options, '![CDATA[').text = urllib.urlencode(extra_options)
-
         return request
 
     def _aim_base_request(self, xact_type, xact={}):

--- a/tests/test_transaction_api.py
+++ b/tests/test_transaction_api.py
@@ -285,6 +285,7 @@ CIM_SALE_REQUEST = '''
       </lineItems>
       <customerProfileId>1234567890</customerProfileId>
       <customerPaymentProfileId>0987654321</customerPaymentProfileId>
+      <cardCode>443</cardCode>
       <customerShippingAddressId>93832984</customerShippingAddressId>
       <order>
         <invoiceNumber>INV0001</invoiceNumber>


### PR DESCRIPTION
``CIMTransactionSchema`` does have a ``card_code`` field but it was not actually being added to the request on the ``_cim_base_request``.

Because of this AIM requests were woking properly but CIM was returning a ``response_reason_code`` 33 with the message ``"Card Code is required"``.

This PR adds card code to the request.