### PR TITLE
Treat lineItems as a nested list field

### DIFF
--- a/authorize/response_parser.py
+++ b/authorize/response_parser.py
@@ -34,6 +34,7 @@ NESTED_LIST_FIELDS = [
     'transactions',
     'batchList',
     'statistics',
+    'lineItems',
 ]
 
 DIRECT_RESPONSE_FIELDS = {


### PR DESCRIPTION
Line items are returned as part of the transaction detail object, and there can be 0 or more line item objects. Current functionality works properly for 0 or 1 line item, but if there are >1 line items the other line items are ignored silently. Simply adding lineItems to this list fixes it for me, and I believe this is the appropriate way to do this (although obviously I defer to the maintainers).

(off subject, this is literally the first time I've done a pull request on github, so if my etiquette is bad, please let me know)