### PR TITLE
Switches Production URL to Akamai URL

### DIFF
--- a/authorize/environment.py
+++ b/authorize/environment.py
@@ -2,4 +2,4 @@
 
 class Environment(object):
     TEST = 'https://apitest.authorize.net/xml/v1/request.api'
-    PRODUCTION = 'https://api.authorize.net/xml/v1/request.api'
+    PRODUCTION = 'https://api2.authorize.net/xml/v1/request.api'


### PR DESCRIPTION
Relevant Issue: #40 

According to [Akamai's documentation](https://community.developer.authorize.net/t5/The-Authorize-Net-Developer-Blog/Important-Authorize-Net-Networking-Change/ba-p/51272), they are changing the API endpoint to another URL. This single line PR makes this change.

Also, the [testing URL hasn't changed](https://community.developer.authorize.net/t5/Integration-and-Testing/Testing-Akamai-in-the-Sandbox/td-p/51379) and switched over last year.