### PR TITLE
fix parser issue on recurring list function

### DIFF
--- a/authorize/response_parser.py
+++ b/authorize/response_parser.py
@@ -36,6 +36,7 @@ NESTED_LIST_FIELDS = [
     'statistics',
     'lineItems',
     'userFields',
+    'subscriptionDetails'
 ]
 
 DIRECT_RESPONSE_FIELDS = {


### PR DESCRIPTION
recurring.list function returns only 1 result even if resultset includes more items. This update fixes this issue.