### PR TITLE
Update refund transaction schema to support order schema

### DIFF
--- a/authorize/apis/transaction_api.py
+++ b/authorize/apis/transaction_api.py
@@ -164,6 +164,8 @@ class TransactionAPI(BaseAPI):
         # Authorize.net doesn't care about the actual date
         E.SubElement(credit_card, 'expirationDate').text = 'XXXXXX'
         E.SubElement(xact_elem, 'refTransId').text = xact['transaction_id']
+        if 'order' in xact:
+            xact_elem.append(create_order(xact['order']))
         return request
 
     def _void_request(self, transaction_id):

--- a/authorize/schemas.py
+++ b/authorize/schemas.py
@@ -392,6 +392,7 @@ class RefundTransactionSchema(colander.MappingSchema):
     last_four = colander.SchemaNode(colander.String(),
                                     validator=colander.Length(max=16),
                                     required=True)
+    order = OrderSchema(missing=colander.drop, required=False)
 
 
 class ListBatchSchema(colander.MappingSchema):

--- a/docs/transaction.rst
+++ b/docs/transaction.rst
@@ -440,7 +440,12 @@ Example
     result = authorize.Transaction.refund({
         'amount': 40.00,
         'last_four': '1111',
-        'transaction_id': '0123456789'
+        'transaction_id': '0123456789',
+        'order': {
+            'invoice_number': 'INV0001',
+            'description': 'Just another invoice...',
+            'order_number': 'PONUM00001',
+        }
     })
 
 


### PR DESCRIPTION
Refund transactions omit "invoice number" and it makes me hard track down transactions with refunds with an invoice number. 
Due to search all transactions that associates an order number, add order schema on refund schema as optional.
