### PR TITLE
add amount field to schema

### DIFF
--- a/authorize/schemas.py
+++ b/authorize/schemas.py
@@ -410,6 +410,10 @@ class UpdateRecurringSchema(colander.MappingSchema):
     trial_amount = colander.SchemaNode(colander.Decimal('0.01'),
                                        validator=colander.Range(0, 20000),
                                        missing=colander.drop)
+    amount = colander.SchemaNode(colander.Decimal('0.01'),
+                                 validator=colander.Range(0, 20000),
+                                 required=False,
+                                 missing=colander.drop)
     total_occurrences = colander.SchemaNode(colander.Integer(),
                                             validator=colander.Range(1, 9999),
                                             missing=colander.drop)


### PR DESCRIPTION
support update of amount field for a subscription.

`In [15]: authorize.Recurring.update('4766443', {'amount': '120.00'})

Out[15]: 
{'messages': [{'message': {'code': 'I00001', 'text': 'Successful.'},
   'result_code': 'Ok'}],
 'profile': {'customer_id': '1813119268', 'payment_id': '1808504361'}}`