### PR TITLE
Correct AttrDict.getattr exception to be AttributeError instead of KeyError

### DIFF
--- a/authorize/response_parser.py
+++ b/authorize/response_parser.py
@@ -58,7 +58,10 @@ class AttrDict(dict):
         dict.__init__(self, *args, **kw)
 
     def __getattr__(self, key):
-        return self[key]
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def __setattr__(self, key, value):
         self[key] = value


### PR DESCRIPTION
Other libs fail when they try to getattr and it throws the wrong exception.

For instance, trying to save the full_response from an authorize Exception to  MongoDB with pymongo yields an error because KeyError is never caught when getattr() is called on the fields.  Had it been AttributeError as expected it wouldn't fail.